### PR TITLE
feat: streaming AI chat for Mutual NDA creator (PL-5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This is a SaaS product to allow users to draft legal agreements based on templat
 
 @catalog.json
 
-The current implementation supports all 11 document types via AI chat with full user authentication and document persistence.
+See the Implementation Status section at the bottom of this file for what is currently built.
 
 # Development process  
 
@@ -27,7 +27,7 @@ The entire project should be packaged into a Docker container.
 The backend should be in backend/ and be a uv project, using FastAPI.  
 The frontend should be in frontend/  
 The database should use SQLLite and be created from scratch each time the Docker container is brought up, allowing for a users table with sign up and sign in.  
-Consider statically building the frontend and serving it via FastAPI, if that will work.  
+The frontend is statically built (`next build` with `output: 'export'`, `trailingSlash: true`) and served via FastAPI's catch-all file handler. No Node.js process runs in production.
 There should be scripts in scripts/ for:  
 
 # Mac
@@ -51,4 +51,20 @@ Accent Yellow: #ecad0a
 Blue Primary: #209dd7  
 Purple Secondary: #753991 (submit buttons)  
 Dark Navy: #032147 (headings)  
-Gray Text: #888888   
+Gray Text: #888888
+
+Colors are declared as Tailwind v4 `@theme` tokens in `frontend/src/app/globals.css` and available as utilities: `text-brand-navy`, `bg-brand-purple`, `text-brand-blue`, etc.
+
+# Implementation Status
+
+## PL-3 — Mutual NDA Creator prototype
+- Client-side Mutual NDA form with live Markdown preview and print-to-PDF
+- No backend, no auth, no AI — pure frontend prototype
+- Components: `NdaForm.tsx`, `NdaPreview.tsx`, `lib/generateNda.ts`
+- Available at `/nda`
+
+## PL-4 — V1 foundation
+- **Backend**: FastAPI uv project in `backend/`. SQLite DB (`prelegal.db`) created fresh on each container start with a `users` table. Endpoints: `POST /api/auth/login` (fake — always succeeds), `GET /api/documents` (serves catalog.json), `GET /api/health`.
+- **Frontend**: Login page at `/` (fake — any credentials accepted, navigates to `/dashboard`). Dashboard at `/dashboard` shows all 12 document types from catalog; only Mutual NDA is active, rest show "Coming Soon". Brand color scheme applied throughout.
+- **Infrastructure**: Two-stage Dockerfile (Node builder → Python runtime), start/stop scripts for Mac, Linux, Windows. Backend at `http://localhost:8000`.
+- **Not yet built**: Real authentication, AI chat, document persistence, document types beyond Mutual NDA.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,12 +2,15 @@ import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 
+load_dotenv(dotenv_path=Path(__file__).parent.parent.parent / ".env")
+
 from app.db import init_db
-from app.routers import auth, documents
+from app.routers import auth, chat, documents
 
 
 @asynccontextmanager
@@ -26,6 +29,7 @@ app.add_middleware(
 )
 
 app.include_router(auth.router, prefix="/api")
+app.include_router(chat.router, prefix="/api")
 app.include_router(documents.router, prefix="/api")
 
 STATIC_DIR = Path(os.getenv("STATIC_DIR", Path(__file__).parent.parent / "static"))

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,0 +1,152 @@
+import json
+import os
+from typing import Any, Literal, Optional
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+from litellm import acompletion
+from pydantic import BaseModel
+
+router = APIRouter()
+
+MODEL = "openrouter/openai/gpt-oss-120b"
+EXTRA_BODY = {"provider": {"order": ["cerebras"]}}
+
+_FIELD_GUIDE = """
+Fields to collect:
+- party1Company: Company name of Party 1
+- party1Name: Full name of the signatory for Party 1
+- party1Title: Job title of the signatory for Party 1
+- party1Address: Email or postal address for notices (Party 1)
+- party1Date: Date Party 1 signs (YYYY-MM-DD)
+- party2Company: Company name of Party 2
+- party2Name: Full name of the signatory for Party 2
+- party2Title: Job title of the signatory for Party 2
+- party2Address: Email or postal address for notices (Party 2)
+- party2Date: Date Party 2 signs (YYYY-MM-DD)
+- purpose: Business purpose of the NDA (lowercase, no trailing period)
+- effectiveDate: Date the NDA takes effect (YYYY-MM-DD)
+- mndaTermType: "expires" (fixed years) or "until_terminated" (indefinite)
+- mndaTermYears: Duration in years as a string, e.g. "2" (only when mndaTermType is "expires")
+- confidentialityTermType: "years" (fixed) or "perpetuity" (forever)
+- confidentialityTermYears: Duration in years as a string (only when confidentialityTermType is "years")
+- governingLaw: US state, e.g. "Delaware"
+- jurisdiction: Court location, e.g. "courts located in New Castle, Delaware"
+- modifications: Any custom modifications to standard terms (optional, usually empty)
+"""
+
+
+def _build_system_prompt(current_fields: dict) -> str:
+    filled = {k: v for k, v in current_fields.items() if v not in ("", None)}
+    missing = [k for k, v in current_fields.items() if v in ("", None)]
+    return f"""You are a friendly legal document assistant helping users fill out a Mutual NDA.
+Your goal is to collect all required information through natural conversation, one or two related fields at a time.
+As users provide information, the document preview updates in real time.
+{_FIELD_GUIDE}
+Current state:
+- Already filled: {json.dumps(filled) if filled else "nothing yet"}
+- Still needed: {", ".join(missing) if missing else "all done!"}
+
+Guidelines:
+- Ask about one topic at a time (e.g. Party 1 company + name together, then title + address)
+- Accept natural phrasing; convert dates to YYYY-MM-DD when extracting
+- Keep replies to 2–4 sentences
+- When everything is filled, congratulate the user and suggest printing/saving the document
+"""
+
+
+class _ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class _NdaFields(BaseModel):
+    party1Company: Optional[str] = None
+    party1Name: Optional[str] = None
+    party1Title: Optional[str] = None
+    party1Address: Optional[str] = None
+    party1Date: Optional[str] = None
+    party2Company: Optional[str] = None
+    party2Name: Optional[str] = None
+    party2Title: Optional[str] = None
+    party2Address: Optional[str] = None
+    party2Date: Optional[str] = None
+    purpose: Optional[str] = None
+    effectiveDate: Optional[str] = None
+    mndaTermType: Optional[Literal["expires", "until_terminated"]] = None
+    mndaTermYears: Optional[str] = None
+    confidentialityTermType: Optional[Literal["years", "perpetuity"]] = None
+    confidentialityTermYears: Optional[str] = None
+    governingLaw: Optional[str] = None
+    jurisdiction: Optional[str] = None
+    modifications: Optional[str] = None
+
+
+class ChatRequest(BaseModel):
+    history: list[_ChatMessage]
+    fields: dict[str, Any]
+
+
+@router.post("/chat/nda")
+async def chat_nda(body: ChatRequest):
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    messages = [{"role": "system", "content": _build_system_prompt(body.fields)}]
+    messages += [{"role": m.role, "content": m.content} for m in body.history]
+
+    async def generate():
+        try:
+            full_reply = ""
+
+            # Phase 1: stream the conversational reply
+            stream = await acompletion(
+                model=MODEL,
+                messages=messages,
+                stream=True,
+                reasoning_effort="low",
+                api_key=api_key,
+                extra_body=EXTRA_BODY,
+            )
+            async for chunk in stream:
+                delta = chunk.choices[0].delta.content or ""
+                full_reply += delta
+                if delta:
+                    yield f"data: {json.dumps({'type': 'text', 'delta': delta})}\n\n"
+
+            # Phase 2: extract field values — use json_object mode for broad provider compatibility
+            extract_messages = messages + [
+                {"role": "assistant", "content": full_reply},
+                {
+                    "role": "user",
+                    "content": (
+                        "Based on the full conversation above, extract every NDA field value "
+                        "that the user has explicitly provided. Convert dates to YYYY-MM-DD. "
+                        "Return numeric year values as strings. Only include fields the user actually stated. "
+                        f"Respond with a JSON object matching this schema (all fields optional): "
+                        f"{_NdaFields.model_json_schema()}"
+                    ),
+                },
+            ]
+            fields_resp = await acompletion(
+                model=MODEL,
+                messages=extract_messages,
+                response_format={"type": "json_object"},
+                reasoning_effort="low",
+                api_key=api_key,
+                extra_body=EXTRA_BODY,
+            )
+            try:
+                extracted = _NdaFields.model_validate_json(
+                    fields_resp.choices[0].message.content
+                )
+                fields_dict = extracted.model_dump(exclude_none=True)
+            except Exception:
+                fields_dict = {}
+
+            yield f"data: {json.dumps({'type': 'fields', 'fields': fields_dict})}\n\n"
+            yield "data: [DONE]\n\n"
+
+        except Exception as exc:
+            yield f"data: {json.dumps({'type': 'error', 'message': str(exc)})}\n\n"
+            yield "data: [DONE]\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,4 +7,5 @@ dependencies = [
     "uvicorn[standard]>=0.34",
     "aiosqlite>=0.20",
     "python-dotenv>=1.0",
+    "litellm>=1.55",
 ]

--- a/frontend/src/app/nda/page.tsx
+++ b/frontend/src/app/nda/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import AppHeader from "@/components/AppHeader";
-import NdaForm from "@/components/NdaForm";
+import NdaChat from "@/components/NdaChat";
 import NdaPreview from "@/components/NdaPreview";
 import { defaultFormData, NdaFormData } from "@/lib/generateNda";
 
@@ -37,9 +37,9 @@ export default function NdaPage() {
 
       {/* Two-column layout */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left: Form */}
-        <div className="w-80 shrink-0 overflow-y-auto border-r bg-white print:hidden">
-          <NdaForm data={formData} onChange={setFormData} />
+        {/* Left: AI Chat */}
+        <div className="w-96 shrink-0 flex flex-col border-r bg-white print:hidden">
+          <NdaChat data={formData} onChange={setFormData} />
         </div>
 
         {/* Right: Preview */}

--- a/frontend/src/components/NdaChat.tsx
+++ b/frontend/src/components/NdaChat.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { NdaFormData } from "@/lib/generateNda";
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface NdaChatProps {
+  data: NdaFormData;
+  onChange: (data: NdaFormData) => void;
+}
+
+const OPENING_MESSAGE: ChatMessage = {
+  role: "assistant",
+  content:
+    "Hi! I'll help you create a Mutual NDA. Let's start — what's the **purpose** of this agreement? For example: *evaluating a potential business partnership* or *exploring a software development collaboration*.",
+};
+
+export default function NdaChat({ data, onChange }: NdaChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([OPENING_MESSAGE]);
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const [streamingContent, setStreamingContent] = useState("");
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  // Keep a ref to data so the SSE closure always has the latest value
+  const latestDataRef = useRef(data);
+  useEffect(() => {
+    latestDataRef.current = data;
+  }, [data]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamingContent]);
+
+  async function sendMessage() {
+    const text = input.trim();
+    if (!text || streaming) return;
+
+    const userMsg: ChatMessage = { role: "user", content: text };
+    const newHistory = [...messages, userMsg];
+    setMessages(newHistory);
+    setInput("");
+    setStreaming(true);
+    setStreamingContent("");
+
+    let fullReply = "";
+
+    try {
+      const response = await fetch("/api/chat/nda", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          history: newHistory,
+          fields: latestDataRef.current,
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      const processLine = (line: string) => {
+        if (!line.startsWith("data: ")) return;
+        const payload = line.slice(6).trim();
+        if (!payload || payload === "[DONE]") return;
+        try {
+          const event = JSON.parse(payload);
+          if (event.type === "text" && event.delta) {
+            fullReply += event.delta;
+            setStreamingContent(fullReply);
+          } else if (event.type === "fields" && event.fields) {
+            onChange({ ...latestDataRef.current, ...event.fields });
+          } else if (event.type === "error") {
+            fullReply = `Sorry, an error occurred: ${event.message}`;
+            setStreamingContent(fullReply);
+          }
+        } catch {
+          // ignore malformed SSE chunks
+        }
+      };
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          // Flush any remaining buffered line
+          if (buffer) processLine(buffer);
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) processLine(line);
+      }
+
+      if (fullReply) {
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: fullReply },
+        ]);
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: "Sorry, something went wrong. Please try again.",
+        },
+      ]);
+    } finally {
+      setStreaming(false);
+      setStreamingContent("");
+      inputRef.current?.focus();
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Message list */}
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {messages.map((msg, i) => (
+          <Bubble key={i} role={msg.role} content={msg.content} />
+        ))}
+
+        {/* Streaming AI reply */}
+        {streaming && streamingContent && (
+          <Bubble role="assistant" content={streamingContent} isStreaming />
+        )}
+
+        {/* Typing indicator while waiting for first token */}
+        {streaming && !streamingContent && (
+          <div className="flex gap-1 pl-1 pt-1">
+            {[0, 150, 300].map((delay) => (
+              <span
+                key={delay}
+                className="w-2 h-2 bg-brand-blue rounded-full animate-bounce"
+                style={{ animationDelay: `${delay}ms` }}
+              />
+            ))}
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <div className="border-t bg-white px-4 py-3 flex gap-2 items-end shrink-0">
+        <textarea
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
+          rows={2}
+          disabled={streaming}
+          className="flex-1 resize-none border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue disabled:opacity-50"
+        />
+        <button
+          onClick={sendMessage}
+          disabled={streaming || !input.trim()}
+          className="bg-brand-purple hover:bg-[#5e2d73] disabled:opacity-50 text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors cursor-pointer self-end"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Bubble({
+  role,
+  content,
+  isStreaming = false,
+}: {
+  role: "user" | "assistant";
+  content: string;
+  isStreaming?: boolean;
+}) {
+  const isUser = role === "user";
+
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[88%] rounded-2xl px-3 py-2 text-sm leading-relaxed ${
+          isUser
+            ? "bg-brand-blue text-white rounded-br-sm"
+            : "bg-gray-100 text-gray-800 rounded-bl-sm"
+        }`}
+      >
+        {isUser ? (
+          <span className="whitespace-pre-wrap">{content}</span>
+        ) : (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
+              strong: ({ children }) => (
+                <strong className="font-semibold">{children}</strong>
+              ),
+              em: ({ children }) => <em className="italic">{children}</em>,
+            }}
+          >
+            {content}
+          </ReactMarkdown>
+        )}
+        {isStreaming && (
+          <span className="inline-block w-0.5 h-3.5 bg-gray-400 ml-0.5 animate-pulse align-middle" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/scripts/start-linux.sh
+++ b/scripts/start-linux.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -e
 
+# Load OPENROUTER_API_KEY from .env
+if [ -f .env ]; then
+  OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d '=' -f2-)
+fi
+
 docker build -t prelegal .
 docker rm -f prelegal 2>/dev/null || true
-docker run -d -p 8000:8000 --name prelegal prelegal
+docker run -d -p 8000:8000 --name prelegal \
+  -e OPENROUTER_API_KEY="$OPENROUTER_API_KEY" \
+  prelegal
 
 echo "Prelegal is running at http://localhost:8000"

--- a/scripts/start-mac.sh
+++ b/scripts/start-mac.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -e
 
+# Load OPENROUTER_API_KEY from .env
+if [ -f .env ]; then
+  OPENROUTER_API_KEY=$(grep -E '^OPENROUTER_API_KEY=' .env | cut -d '=' -f2-)
+fi
+
 docker build -t prelegal .
 docker rm -f prelegal 2>/dev/null || true
-docker run -d -p 8000:8000 --name prelegal prelegal
+docker run -d -p 8000:8000 --name prelegal \
+  -e OPENROUTER_API_KEY="$OPENROUTER_API_KEY" \
+  prelegal
 
 echo "Prelegal is running at http://localhost:8000"

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -1,5 +1,10 @@
+$apiKey = ""
+if (Test-Path .env) {
+  $apiKey = (Get-Content .env | Where-Object { $_ -match "^OPENROUTER_API_KEY=" }) -replace "^OPENROUTER_API_KEY=", ""
+}
+
 docker build -t prelegal .
 docker rm -f prelegal 2>$null
-docker run -d -p 8000:8000 --name prelegal prelegal
+docker run -d -p 8000:8000 --name prelegal -e "OPENROUTER_API_KEY=$apiKey" prelegal
 
 Write-Host "Prelegal is running at http://localhost:8000"


### PR DESCRIPTION
## Summary

- **AI chat replaces the manual form** on the NDA creator page — freeform conversation with an AI that asks questions and populates the document in real time
- **Streaming replies** via SSE (Server-Sent Events): words appear progressively with a typing indicator while waiting for the first token
- **Structured field extraction** after each reply: the AI extracts any NDA field values mentioned and the document preview updates automatically
- **Error resilience**: backend exceptions yield a typed SSE error event (no silent truncation); frontend handles empty replies and malformed chunks gracefully

## How it works

1. User lands on `/nda` → AI opens with a greeting asking for the purpose of the agreement
2. User responds naturally → `POST /api/chat/nda` is called with chat history + current field state
3. Backend streams the AI reply (litellm + OpenRouter/Cerebras), then runs a second structured extraction call
4. Frontend streams text into the chat bubble in real time; when the `fields` SSE event arrives, `NdaFormData` is merged and the document preview updates

## Test plan

- [ ] Start backend locally: `cd backend && uv run uvicorn app.main:app --reload` (requires `.env` with `OPENROUTER_API_KEY`)
- [ ] Navigate to `http://localhost:8000/nda` (or `http://localhost:3000/nda` in dev)
- [ ] Verify AI opening message appears immediately
- [ ] Type a purpose (e.g. "evaluating a partnership") — reply should stream in, document preview should update
- [ ] Continue conversation: party names, dates, governing law — verify each populates the document
- [ ] Test Enter-to-send and Shift+Enter for newline
- [ ] Test error case: stop the backend mid-conversation — verify error message appears in chat, form is not locked

Closes PL-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)