### PR TITLE
feat: expand AI chat to all 12 supported document types (PL-6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,21 @@ Colors are declared as Tailwind v4 `@theme` tokens in `frontend/src/app/globals.
 - **Frontend**: Login page at `/` (fake — any credentials accepted, navigates to `/dashboard`). Dashboard at `/dashboard` shows all 12 document types from catalog; only Mutual NDA is active, rest show "Coming Soon". Brand color scheme applied throughout.
 - **Infrastructure**: Two-stage Dockerfile (Node builder → Python runtime), start/stop scripts for Mac, Linux, Windows. Backend at `http://localhost:8000`.
 - **Not yet built**: Real authentication, AI chat, document persistence, document types beyond Mutual NDA.
+
+## PL-5 — AI chat for Mutual NDA
+- Streaming AI chat interface replaces the static NDA form
+- Backend: `POST /api/chat/nda` streams SSE (text deltas + field extraction). Two LiteLLM calls per turn: stream for conversational reply, non-stream for structured field extraction via `_NdaFields` Pydantic schema
+- Frontend: `NdaChat.tsx` (manual SSE reader via ReadableStream, not EventSource), `NdaPreview.tsx` (live Markdown render), `nda/page.tsx` owns shared state
+- Document generation is entirely client-side in `lib/generateNda.ts` (cover page + standard terms as TypeScript string templates)
+
+## PL-6 — Expand to all supported legal document types
+- All 12 document types are now active in the dashboard (no more "Coming Soon")
+- `Mutual-NDA-coverpage.md` routes to `/nda` (same flow as Mutual NDA)
+- All other 10 document types get generic chat+preview pages at `/document/[slug]`
+- **Backend**: `POST /api/chat/document` — generic streaming SSE endpoint; accepts `docType` filename, reads party roles from a config map, uses `_GenericDocFields` schema (party info, dates, term, description, fees, governing law). System prompt includes full catalog so AI can handle unsupported document requests and suggest alternatives. `GET /api/documents/template/{filename}` — serves raw template markdown (validated against catalog allowlist, cached).
+- **Frontend**:
+  - `lib/documentTypes.ts` — maps slugs to document config (name, filename, party1Role, party2Role)
+  - `lib/generateDocument.ts` — `DocFormData` type + `generateCoverPage()` (cover page with key terms table + signature block)
+  - `components/DocumentChat.tsx` — generic chat (same SSE pattern as NdaChat, parameterized by `DocConfig`)
+  - `components/DocumentPreview.tsx` — fetches standard terms from backend, renders cover page + sanitized template markdown
+  - `app/document/[slug]/page.tsx` + `DocumentPageClient.tsx` — server/client split required by Next.js static export + `generateStaticParams`

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,8 +1,9 @@
 import json
 import os
+from pathlib import Path
 from typing import Any, Literal, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 from litellm import acompletion
 from pydantic import BaseModel
@@ -11,6 +12,24 @@ router = APIRouter()
 
 MODEL = "openrouter/openai/gpt-oss-120b"
 EXTRA_BODY = {"provider": {"order": ["cerebras"]}}
+TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
+CATALOG_PATH = Path(__file__).parent.parent.parent / "catalog.json"
+
+_AVAILABLE_DOCS = """Available documents this platform can generate:
+- Mutual NDA (Mutual-NDA.md): Mutual non-disclosure agreement between two parties
+- Mutual NDA Cover Page (Mutual-NDA-coverpage.md): Cover page for the Mutual NDA
+- Cloud Service Agreement (CSA.md): SaaS subscription agreement
+- Service Level Agreement (SLA.md): Uptime and support commitments addendum
+- Design Partner Agreement (Design-Partner-Agreement.md): Early-access design partner program
+- Professional Services Agreement (PSA.md): Custom work or consulting engagement
+- Data Processing Agreement (DPA.md): GDPR-compliant data processing terms
+- Partnership Agreement (Partnership-Agreement.md): Co-marketing, referral, or integration partnership
+- Software License Agreement (Software-License-Agreement.md): On-premises software license
+- Pilot Agreement (Pilot-Agreement.md): Short-term evaluation or proof-of-concept
+- Business Associate Agreement (BAA.md): HIPAA-compliant business associate agreement
+- AI Addendum (AI-Addendum.md): Addendum covering AI/ML feature usage
+
+If the user asks for a document type not on this list, explain that it is not currently supported and suggest the closest available document."""
 
 _FIELD_GUIDE = """
 Fields to collect:
@@ -136,6 +155,170 @@ async def chat_nda(body: ChatRequest):
             )
             try:
                 extracted = _NdaFields.model_validate_json(
+                    fields_resp.choices[0].message.content
+                )
+                fields_dict = extracted.model_dump(exclude_none=True)
+            except Exception:
+                fields_dict = {}
+
+            yield f"data: {json.dumps({'type': 'fields', 'fields': fields_dict})}\n\n"
+            yield "data: [DONE]\n\n"
+
+        except Exception as exc:
+            yield f"data: {json.dumps({'type': 'error', 'message': str(exc)})}\n\n"
+            yield "data: [DONE]\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+# ─── Generic document chat ────────────────────────────────────────────────────
+
+_GENERIC_FIELD_GUIDE = """
+Fields to collect:
+- party1Company: Company name of the first party
+- party1Name: Full name of the signatory for the first party
+- party1Title: Job title of the signatory for the first party
+- party1Address: Email or postal address for notices (first party)
+- party1Date: Date first party signs (YYYY-MM-DD)
+- party2Company: Company name of the second party
+- party2Name: Full name of the signatory for the second party
+- party2Title: Job title of the signatory for the second party
+- party2Address: Email or postal address for notices (second party)
+- party2Date: Date second party signs (YYYY-MM-DD)
+- effectiveDate: Date the agreement takes effect (YYYY-MM-DD)
+- term: Duration of the agreement, e.g. "1 year", "2 years", "ongoing"
+- description: Brief description of the specific engagement or scope
+- fees: Fee amount and payment terms, if any (e.g. "$5,000/month"); leave blank if no fees
+- governingLaw: Governing state, e.g. "Delaware"
+- jurisdiction: Court location, e.g. "courts located in New Castle, Delaware"
+"""
+
+
+def _build_doc_system_prompt(doc_name: str, party1_role: str, party2_role: str, current_fields: dict) -> str:
+    filled = {k: v for k, v in current_fields.items() if v not in ("", None)}
+    missing = [k for k, v in current_fields.items() if v in ("", None)]
+    return f"""You are a friendly legal document assistant helping users fill out a {doc_name}.
+The two parties are referred to as "{party1_role}" (first party) and "{party2_role}" (second party).
+Your goal is to collect all required information through natural conversation, one or two related fields at a time.
+As users provide information, the document preview updates in real time.
+{_GENERIC_FIELD_GUIDE}
+{_AVAILABLE_DOCS}
+Current state:
+- Already filled: {json.dumps(filled) if filled else "nothing yet"}
+- Still needed: {", ".join(missing) if missing else "all done!"}
+
+Guidelines:
+- Address the parties by their roles ({party1_role} and {party2_role}) when asking questions
+- Ask about one topic at a time (e.g. {party1_role} company + name together, then title + address)
+- Accept natural phrasing; convert dates to YYYY-MM-DD when extracting
+- Keep replies to 2–4 sentences
+- When everything is filled, congratulate the user and suggest printing/saving the document
+"""
+
+
+class _GenericDocFields(BaseModel):
+    party1Company: Optional[str] = None
+    party1Name: Optional[str] = None
+    party1Title: Optional[str] = None
+    party1Address: Optional[str] = None
+    party1Date: Optional[str] = None
+    party2Company: Optional[str] = None
+    party2Name: Optional[str] = None
+    party2Title: Optional[str] = None
+    party2Address: Optional[str] = None
+    party2Date: Optional[str] = None
+    effectiveDate: Optional[str] = None
+    term: Optional[str] = None
+    description: Optional[str] = None
+    fees: Optional[str] = None
+    governingLaw: Optional[str] = None
+    jurisdiction: Optional[str] = None
+
+
+_DOC_ROLES: dict[str, tuple[str, str]] = {
+    "CSA.md": ("Provider", "Customer"),
+    "SLA.md": ("Provider", "Customer"),
+    "Design-Partner-Agreement.md": ("Provider", "Partner"),
+    "PSA.md": ("Provider", "Customer"),
+    "DPA.md": ("Provider", "Customer"),
+    "Partnership-Agreement.md": ("Company", "Partner"),
+    "Software-License-Agreement.md": ("Provider", "Customer"),
+    "Pilot-Agreement.md": ("Provider", "Customer"),
+    "BAA.md": ("Business Associate", "Covered Entity"),
+    "AI-Addendum.md": ("Provider", "Customer"),
+}
+
+_DOC_NAMES: dict[str, str] = {}
+
+
+def _get_doc_name(filename: str) -> str:
+    global _DOC_NAMES
+    if not _DOC_NAMES and CATALOG_PATH.exists():
+        catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+        _DOC_NAMES = {entry["filename"]: entry["name"] for entry in catalog}
+    return _DOC_NAMES.get(filename, filename)
+
+
+class GenericChatRequest(BaseModel):
+    history: list[_ChatMessage]
+    fields: dict[str, Any]
+    docType: str
+
+
+@router.post("/chat/document")
+async def chat_document(body: GenericChatRequest):
+    filename = body.docType
+    if filename not in _DOC_ROLES:
+        raise HTTPException(status_code=400, detail=f"Unsupported document type: {filename}")
+
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    party1_role, party2_role = _DOC_ROLES[filename]
+    doc_name = _get_doc_name(filename)
+
+    messages = [{"role": "system", "content": _build_doc_system_prompt(doc_name, party1_role, party2_role, body.fields)}]
+    messages += [{"role": m.role, "content": m.content} for m in body.history]
+
+    async def generate():
+        try:
+            full_reply = ""
+
+            stream = await acompletion(
+                model=MODEL,
+                messages=messages,
+                stream=True,
+                reasoning_effort="low",
+                api_key=api_key,
+                extra_body=EXTRA_BODY,
+            )
+            async for chunk in stream:
+                delta = chunk.choices[0].delta.content or ""
+                full_reply += delta
+                if delta:
+                    yield f"data: {json.dumps({'type': 'text', 'delta': delta})}\n\n"
+
+            extract_messages = messages + [
+                {"role": "assistant", "content": full_reply},
+                {
+                    "role": "user",
+                    "content": (
+                        f"Based on the full conversation above, extract every field value "
+                        f"that the user has explicitly provided for this {doc_name}. "
+                        "Convert dates to YYYY-MM-DD. Only include fields the user actually stated. "
+                        f"Respond with a JSON object matching this schema (all fields optional): "
+                        f"{_GenericDocFields.model_json_schema()}"
+                    ),
+                },
+            ]
+            fields_resp = await acompletion(
+                model=MODEL,
+                messages=extract_messages,
+                response_format={"type": "json_object"},
+                reasoning_effort="low",
+                api_key=api_key,
+                extra_body=EXTRA_BODY,
+            )
+            try:
+                extracted = _GenericDocFields.model_validate_json(
                     fields_resp.choices[0].message.content
                 )
                 fields_dict = extracted.model_dump(exclude_none=True)

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -2,10 +2,25 @@ import json
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import PlainTextResponse
 
 router = APIRouter()
 
 CATALOG_PATH = Path(__file__).parent.parent.parent / "catalog.json"
+TEMPLATES_DIR = Path(__file__).parent.parent.parent / "templates"
+
+
+_ALLOWED_FILENAMES: set[str] | None = None
+
+
+def _allowed_filenames() -> set[str]:
+    global _ALLOWED_FILENAMES
+    if _ALLOWED_FILENAMES is None:
+        if not CATALOG_PATH.exists():
+            return set()
+        catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+        _ALLOWED_FILENAMES = {entry["filename"] for entry in catalog}
+    return _ALLOWED_FILENAMES
 
 
 @router.get("/documents")
@@ -13,3 +28,13 @@ async def get_catalog():
     if not CATALOG_PATH.exists():
         raise HTTPException(status_code=500, detail="Catalog not found")
     return json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+
+
+@router.get("/documents/template/{filename}", response_class=PlainTextResponse)
+async def get_template(filename: str):
+    if filename not in _allowed_filenames():
+        raise HTTPException(status_code=404, detail="Template not found")
+    template_path = TEMPLATES_DIR / filename
+    if not template_path.is_file():
+        raise HTTPException(status_code=404, detail="Template file not found")
+    return template_path.read_text(encoding="utf-8")

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -12,6 +12,17 @@ interface CatalogEntry {
 
 const FILENAME_TO_ROUTE: Record<string, string> = {
   "Mutual-NDA.md": "/nda",
+  "Mutual-NDA-coverpage.md": "/nda",
+  "CSA.md": "/document/CSA",
+  "SLA.md": "/document/SLA",
+  "Design-Partner-Agreement.md": "/document/Design-Partner-Agreement",
+  "PSA.md": "/document/PSA",
+  "DPA.md": "/document/DPA",
+  "Partnership-Agreement.md": "/document/Partnership-Agreement",
+  "Software-License-Agreement.md": "/document/Software-License-Agreement",
+  "Pilot-Agreement.md": "/document/Pilot-Agreement",
+  "BAA.md": "/document/BAA",
+  "AI-Addendum.md": "/document/AI-Addendum",
 };
 
 export default function DashboardPage() {

--- a/frontend/src/app/document/[slug]/DocumentPageClient.tsx
+++ b/frontend/src/app/document/[slug]/DocumentPageClient.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import AppHeader from "@/components/AppHeader";
+import DocumentChat from "@/components/DocumentChat";
+import DocumentPreview from "@/components/DocumentPreview";
+import { defaultDocFormData, DocFormData } from "@/lib/generateDocument";
+import { DocConfig } from "@/lib/documentTypes";
+
+interface DocumentPageClientProps {
+  config: DocConfig;
+}
+
+export default function DocumentPageClient({ config }: DocumentPageClientProps) {
+  const [formData, setFormData] = useState<DocFormData>(() => ({
+    ...defaultDocFormData,
+    effectiveDate: new Date().toISOString().split("T")[0],
+  }));
+
+  return (
+    <div className="flex flex-col h-screen">
+      <AppHeader />
+
+      {/* Subheader */}
+      <div className="flex items-center justify-between px-6 py-2 bg-white border-b print:hidden">
+        <span className="text-sm font-medium text-brand-navy">{config.name} Creator</span>
+      </div>
+
+      {/* Two-column layout */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left: AI Chat */}
+        <div className="w-96 shrink-0 flex flex-col border-r bg-white print:hidden">
+          <DocumentChat data={formData} onChange={setFormData} config={config} />
+        </div>
+
+        {/* Right: Preview */}
+        <div className="flex-1 overflow-hidden">
+          <DocumentPreview data={formData} config={config} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/document/[slug]/page.tsx
+++ b/frontend/src/app/document/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { DOCUMENT_CONFIGS, ALL_SLUGS } from "@/lib/documentTypes";
+import DocumentPageClient from "./DocumentPageClient";
+
+export function generateStaticParams() {
+  return ALL_SLUGS.map((slug) => ({ slug }));
+}
+
+interface PageProps {
+  params: { slug: string };
+}
+
+export default function DocumentPage({ params }: PageProps) {
+  const config = DOCUMENT_CONFIGS[params.slug];
+  // Unknown slugs are not generated at build time; static export falls back to root index.html
+  if (!config) return null;
+
+  return <DocumentPageClient config={config} />;
+}

--- a/frontend/src/components/DocumentChat.tsx
+++ b/frontend/src/components/DocumentChat.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { DocFormData } from "@/lib/generateDocument";
+import { DocConfig } from "@/lib/documentTypes";
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface DocumentChatProps {
+  data: DocFormData;
+  onChange: (data: DocFormData) => void;
+  config: DocConfig;
+}
+
+function buildOpeningMessage(config: DocConfig): ChatMessage {
+  return {
+    role: "assistant",
+    content: `Hi! I'll help you create a **${config.name}**. Let's start — can you briefly describe what this agreement is for? For example, the ${config.descriptionLabel}.`,
+  };
+}
+
+export default function DocumentChat({ data, onChange, config }: DocumentChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>(() => [buildOpeningMessage(config)]);
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const [streamingContent, setStreamingContent] = useState("");
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const latestDataRef = useRef(data);
+  useEffect(() => {
+    latestDataRef.current = data;
+  }, [data]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamingContent]);
+
+  async function sendMessage() {
+    const text = input.trim();
+    if (!text || streaming) return;
+
+    const userMsg: ChatMessage = { role: "user", content: text };
+    const newHistory = [...messages, userMsg];
+    setMessages(newHistory);
+    setInput("");
+    setStreaming(true);
+    setStreamingContent("");
+
+    let fullReply = "";
+
+    try {
+      const response = await fetch("/api/chat/document", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          history: newHistory,
+          fields: latestDataRef.current,
+          docType: config.filename,
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      const processLine = (line: string) => {
+        if (!line.startsWith("data: ")) return;
+        const payload = line.slice(6).trim();
+        if (!payload || payload === "[DONE]") return;
+        try {
+          const event = JSON.parse(payload);
+          if (event.type === "text" && event.delta) {
+            fullReply += event.delta;
+            setStreamingContent(fullReply);
+          } else if (event.type === "fields" && event.fields) {
+            onChange({ ...latestDataRef.current, ...event.fields });
+          } else if (event.type === "error") {
+            fullReply = `Sorry, an error occurred: ${event.message}`;
+            setStreamingContent(fullReply);
+          }
+        } catch {
+          // ignore malformed SSE chunks
+        }
+      };
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          if (buffer) processLine(buffer);
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) processLine(line);
+      }
+
+      if (fullReply) {
+        setMessages((prev) => [...prev, { role: "assistant", content: fullReply }]);
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: "Sorry, something went wrong. Please try again." },
+      ]);
+    } finally {
+      setStreaming(false);
+      setStreamingContent("");
+      inputRef.current?.focus();
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
+        {messages.map((msg, i) => (
+          <Bubble key={i} role={msg.role} content={msg.content} />
+        ))}
+
+        {streaming && streamingContent && (
+          <Bubble role="assistant" content={streamingContent} isStreaming />
+        )}
+
+        {streaming && !streamingContent && (
+          <div className="flex gap-1 pl-1 pt-1">
+            {[0, 150, 300].map((delay) => (
+              <span
+                key={delay}
+                className="w-2 h-2 bg-brand-blue rounded-full animate-bounce"
+                style={{ animationDelay: `${delay}ms` }}
+              />
+            ))}
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className="border-t bg-white px-4 py-3 flex gap-2 items-end shrink-0">
+        <textarea
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
+          rows={2}
+          disabled={streaming}
+          className="flex-1 resize-none border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue disabled:opacity-50"
+        />
+        <button
+          onClick={sendMessage}
+          disabled={streaming || !input.trim()}
+          className="bg-brand-purple hover:bg-[#5e2d73] disabled:opacity-50 text-white rounded-lg px-4 py-2 text-sm font-medium transition-colors cursor-pointer self-end"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Bubble({
+  role,
+  content,
+  isStreaming = false,
+}: {
+  role: "user" | "assistant";
+  content: string;
+  isStreaming?: boolean;
+}) {
+  const isUser = role === "user";
+
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[88%] rounded-2xl px-3 py-2 text-sm leading-relaxed ${
+          isUser
+            ? "bg-brand-blue text-white rounded-br-sm"
+            : "bg-gray-100 text-gray-800 rounded-bl-sm"
+        }`}
+      >
+        {isUser ? (
+          <span className="whitespace-pre-wrap">{content}</span>
+        ) : (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: ({ children }) => <p className="mb-1 last:mb-0">{children}</p>,
+              strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+              em: ({ children }) => <em className="italic">{children}</em>,
+            }}
+          >
+            {content}
+          </ReactMarkdown>
+        )}
+        {isStreaming && (
+          <span className="inline-block w-0.5 h-3.5 bg-gray-400 ml-0.5 animate-pulse align-middle" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DocumentPreview.tsx
+++ b/frontend/src/components/DocumentPreview.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
+import { DocFormData, generateCoverPage } from "@/lib/generateDocument";
+import { DocConfig } from "@/lib/documentTypes";
+
+interface DocumentPreviewProps {
+  data: DocFormData;
+  config: DocConfig;
+}
+
+export default function DocumentPreview({ data, config }: DocumentPreviewProps) {
+  const [templateContent, setTemplateContent] = useState<string>("");
+  const [templateError, setTemplateError] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/documents/template/${config.filename}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.text();
+      })
+      .then(setTemplateContent)
+      .catch(() => setTemplateError(true));
+  }, [config.filename]);
+
+  const coverPage = useMemo(
+    () => generateCoverPage(data, config.name, config.party1Role, config.party2Role),
+    [data, config]
+  );
+
+  const fullDocument = useMemo(() => {
+    if (!templateContent) return coverPage;
+    // Strip HTML span tags from the standard terms for clean rendering
+    const cleanTerms = templateContent.replace(/<span[^>]*>|<\/span>/g, "");
+    return `${coverPage}\n\n---\n\n# Standard Terms\n\n${cleanTerms}`;
+  }, [coverPage, templateContent]);
+
+  function handlePrint() {
+    window.print();
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-6 py-3 border-b bg-gray-50 print:hidden">
+        <h2 className="text-lg font-bold text-gray-800">Document Preview</h2>
+        <button
+          onClick={handlePrint}
+          className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2 rounded-md transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+            />
+          </svg>
+          Print / Save as PDF
+        </button>
+      </div>
+
+      {/* Document */}
+      <div className="flex-1 overflow-y-auto p-8 bg-white" id="legal-document">
+        {templateError && (
+          <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded text-sm text-yellow-800">
+            Standard terms could not be loaded. The cover page is still available above.
+          </div>
+        )}
+        <div className="max-w-3xl mx-auto prose prose-sm prose-gray">
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeSanitize]}
+            components={{
+              h1: ({ children }) => (
+                <h1 className="text-2xl font-bold text-gray-900 mb-4 mt-6">{children}</h1>
+              ),
+              h2: ({ children }) => (
+                <h2 className="text-xl font-bold text-gray-800 mb-3 mt-6 border-b pb-1">{children}</h2>
+              ),
+              h3: ({ children }) => (
+                <h3 className="text-base font-bold text-gray-800 mb-2 mt-4">{children}</h3>
+              ),
+              p: ({ children }) => (
+                <p className="text-gray-700 text-sm leading-relaxed mb-3">{children}</p>
+              ),
+              table: ({ children }) => (
+                <table className="w-full border-collapse border border-gray-300 text-sm my-4">
+                  {children}
+                </table>
+              ),
+              th: ({ children }) => (
+                <th className="border border-gray-300 px-3 py-2 bg-gray-50 text-left font-semibold text-gray-700">
+                  {children}
+                </th>
+              ),
+              td: ({ children }) => (
+                <td className="border border-gray-300 px-3 py-2 text-gray-700 min-h-8">
+                  {children}
+                </td>
+              ),
+              hr: () => <hr className="my-8 border-gray-300" />,
+              strong: ({ children }) => (
+                <strong className="font-semibold text-gray-900">{children}</strong>
+              ),
+              a: ({ href, children }) => (
+                <a href={href} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">
+                  {children}
+                </a>
+              ),
+              em: ({ children }) => (
+                <em className="text-gray-500 not-italic text-xs">{children}</em>
+              ),
+              li: ({ children }) => (
+                <li className="text-gray-700 text-sm mb-1">{children}</li>
+              ),
+            }}
+          >
+            {fullDocument}
+          </ReactMarkdown>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/documentTypes.ts
+++ b/frontend/src/lib/documentTypes.ts
@@ -1,0 +1,82 @@
+export interface DocConfig {
+  name: string;
+  filename: string;
+  party1Role: string;
+  party2Role: string;
+  descriptionLabel: string;
+}
+
+export const DOCUMENT_CONFIGS: Record<string, DocConfig> = {
+  CSA: {
+    name: "Cloud Service Agreement",
+    filename: "CSA.md",
+    party1Role: "Provider",
+    party2Role: "Customer",
+    descriptionLabel: "cloud service being provided",
+  },
+  SLA: {
+    name: "Service Level Agreement",
+    filename: "SLA.md",
+    party1Role: "Provider",
+    party2Role: "Customer",
+    descriptionLabel: "service covered by this SLA",
+  },
+  "Design-Partner-Agreement": {
+    name: "Design Partner Agreement",
+    filename: "Design-Partner-Agreement.md",
+    party1Role: "Provider",
+    party2Role: "Partner",
+    descriptionLabel: "product being evaluated by the design partner",
+  },
+  PSA: {
+    name: "Professional Services Agreement",
+    filename: "PSA.md",
+    party1Role: "Provider",
+    party2Role: "Customer",
+    descriptionLabel: "services being provided",
+  },
+  DPA: {
+    name: "Data Processing Agreement",
+    filename: "DPA.md",
+    party1Role: "Provider",
+    party2Role: "Customer",
+    descriptionLabel: "data processing activities covered",
+  },
+  "Partnership-Agreement": {
+    name: "Partnership Agreement",
+    filename: "Partnership-Agreement.md",
+    party1Role: "Company",
+    party2Role: "Partner",
+    descriptionLabel: "nature of the partnership (e.g., co-marketing, referral)",
+  },
+  "Software-License-Agreement": {
+    name: "Software License Agreement",
+    filename: "Software-License-Agreement.md",
+    party1Role: "Provider",
+    party2Role: "Customer",
+    descriptionLabel: "software being licensed",
+  },
+  "Pilot-Agreement": {
+    name: "Pilot Agreement",
+    filename: "Pilot-Agreement.md",
+    party1Role: "Provider",
+    party2Role: "Customer",
+    descriptionLabel: "product being evaluated in this pilot",
+  },
+  BAA: {
+    name: "Business Associate Agreement",
+    filename: "BAA.md",
+    party1Role: "Business Associate",
+    party2Role: "Covered Entity",
+    descriptionLabel: "services provided that involve protected health information",
+  },
+  "AI-Addendum": {
+    name: "AI Addendum",
+    filename: "AI-Addendum.md",
+    party1Role: "Provider",
+    party2Role: "Customer",
+    descriptionLabel: "AI/ML features covered by this addendum",
+  },
+};
+
+export const ALL_SLUGS = Object.keys(DOCUMENT_CONFIGS);

--- a/frontend/src/lib/generateDocument.ts
+++ b/frontend/src/lib/generateDocument.ts
@@ -1,0 +1,88 @@
+export interface DocFormData {
+  party1Company: string;
+  party1Name: string;
+  party1Title: string;
+  party1Address: string;
+  party1Date: string;
+  party2Company: string;
+  party2Name: string;
+  party2Title: string;
+  party2Address: string;
+  party2Date: string;
+  effectiveDate: string;
+  term: string;
+  description: string;
+  fees: string;
+  governingLaw: string;
+  jurisdiction: string;
+}
+
+export const defaultDocFormData: DocFormData = {
+  party1Company: "",
+  party1Name: "",
+  party1Title: "",
+  party1Address: "",
+  party1Date: "",
+  party2Company: "",
+  party2Name: "",
+  party2Title: "",
+  party2Address: "",
+  party2Date: "",
+  effectiveDate: "",
+  term: "",
+  description: "",
+  fees: "",
+  governingLaw: "",
+  jurisdiction: "",
+};
+
+function escapeCell(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function escapeInline(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/[_*`[\]]/g, "\\$&");
+}
+
+export function generateCoverPage(
+  data: DocFormData,
+  docName: string,
+  party1Role: string,
+  party2Role: string
+): string {
+  const effectiveDate = escapeInline(data.effectiveDate || "[Effective Date]");
+  const term = escapeInline(data.term || "[Term]");
+  const description = escapeInline(data.description || "[Description]");
+  const governingLaw = escapeInline(data.governingLaw || "[Governing Law]");
+  const jurisdiction = escapeInline(data.jurisdiction || "[Jurisdiction]");
+
+  const keyTermsRows = [
+    `| Effective Date | ${effectiveDate} |`,
+    `| Agreement Term | ${term} |`,
+    `| Description | ${description} |`,
+    data.fees ? `| Fees | ${escapeInline(data.fees)} |` : null,
+    `| Governing Law | ${governingLaw} |`,
+    `| Jurisdiction | ${jurisdiction} |`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return `# ${docName}
+
+## Key Terms
+
+| Term | Details |
+|:---|:---|
+${keyTermsRows}
+
+By signing below, each party agrees to enter into this Agreement as of the Effective Date.
+
+| | ${party1Role.toUpperCase()} | ${party2Role.toUpperCase()} |
+|:---|:---:|:---:|
+| **Signature** | | |
+| **Print Name** | ${escapeCell(data.party1Name)} | ${escapeCell(data.party2Name)} |
+| **Title** | ${escapeCell(data.party1Title)} | ${escapeCell(data.party2Title)} |
+| **Company** | ${escapeCell(data.party1Company)} | ${escapeCell(data.party2Company)} |
+| **Notice Address** | ${escapeCell(data.party1Address)} | ${escapeCell(data.party2Address)} |
+| **Date** | ${escapeCell(data.party1Date)} | ${escapeCell(data.party2Date)} |`;
+}


### PR DESCRIPTION
## Summary

- All 12 document types in the catalog are now active — no more "Coming Soon" on the dashboard
- A single generic AI chat + live preview page (`/document/[slug]`) handles all 10 non-NDA document types (Mutual NDA stays at `/nda`)
- The AI knows the full catalog and can handle unsupported document requests by suggesting the closest alternative

## What was built

### Backend
- `POST /api/chat/document` — generic streaming SSE endpoint; accepts `docType` (filename), streams conversational reply then extracts fields via `_GenericDocFields` Pydantic schema (party info, dates, term, description, fees, governing law). Party role labels (Provider/Customer, Business Associate/Covered Entity, etc.) are configured per document type.
- `GET /api/documents/template/{filename}` — serves raw template markdown, validated against catalog allowlist (cached), used by the frontend preview to display standard terms.

### Frontend
- `lib/documentTypes.ts` — maps slugs to doc config (name, filename, party roles)
- `lib/generateDocument.ts` — `DocFormData` type + `generateCoverPage()` (key terms table + signature block)
- `components/DocumentChat.tsx` — generic chat (same SSE pattern as `NdaChat`, parameterized by `DocConfig`)
- `components/DocumentPreview.tsx` — fetches standard terms from backend, renders cover page + sanitized template markdown live as fields are filled
- `app/document/[slug]/page.tsx` + `DocumentPageClient.tsx` — server/client split required by Next.js static export + `generateStaticParams` for all 10 slugs
- Dashboard updated to route all 12 catalog entries

## Test plan

- [ ] Dashboard shows all 12 documents with "Create" buttons (no "Coming Soon")
- [ ] Clicking any non-NDA document navigates to `/document/[slug]`
- [ ] Chat opening message names the correct document type
- [ ] AI collects party info, dates, governing law, etc. and preview updates in real time
- [ ] Clicking "Mutual NDA Cover Page" goes to `/nda` (same as Mutual NDA)
- [ ] Asking the AI for an unsupported document (e.g. "employment contract") gets a helpful response suggesting an alternative
- [ ] Print / Save as PDF works on the generic document pages
- [ ] Build succeeds: `npm run build` in `frontend/` generates all 16 routes including 10 `/document/*` pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)